### PR TITLE
Add CLion IDE project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 *.user
 *.swp
 *~
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@
 *.user
 *.swp
 *~
-/.idea/
+.idea/


### PR DESCRIPTION
CLion works directly with CMake files, but does leave some project files around in the /.idea/ directory.  This commit adds this directory to the .gitignore so that these project files are not accidentally included by contributors using CLion.
